### PR TITLE
Remove the private set from ArangoDatabase.ClientSetting in order to use a proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # Build results
 
 [Dd]ebug/
+[Pp]ackages/
 [Rr]elease/
 x64/
 build/

--- a/ArangoDB.Client/ArangoDatabase.cs
+++ b/ArangoDB.Client/ArangoDatabase.cs
@@ -28,7 +28,7 @@ namespace ArangoDB.Client
 
         public DatabaseSetting Setting { get; set; }
 
-        public static ClientSetting ClientSetting { get; private set; }
+        public static ClientSetting ClientSetting { get; set; }
 
         internal bool HttpInitialized { get; set; }
 


### PR DESCRIPTION
Issue #3 

Remove the private set from ArangoDatabase.ClientSetting in order to use a proxy

Added to .gitignore no ignore the folder packages