### PR TITLE
Exception while creating a database

### DIFF
--- a/ArangoDB.Client/ArangoDatabaseCommands.cs
+++ b/ArangoDB.Client/ArangoDatabaseCommands.cs
@@ -128,7 +128,7 @@ namespace ArangoDB.Client
                 Users = users
             };
 
-            var result = await command.RequestGenericSingleResult<bool, InheritedCommandResult<bool>>().ConfigureAwait(false);
+            var result = await command.RequestGenericSingleResult<bool, InheritedCommandResult<bool>>(data).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
The variable data to create the database was not sent to arango and it returned the exception `database name invalid. ErrorNumber: 1229 HttpStatusCode: 400`