### PR TITLE
Change the way the proxy is assigned to work with mono

### DIFF
--- a/src/ArangoDB.Client/Http/HttpConnection.cs
+++ b/src/ArangoDB.Client/Http/HttpConnection.cs
@@ -1,8 +1,5 @@
 ﻿using ArangoDB.Client.Serialization;
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -19,17 +16,24 @@ namespace ArangoDB.Client.Http
         {
             connectionHandler = new HttpConnectionHandler();
             var proxy = ArangoDatabase.ClientSetting.Proxy;
-            connectionHandler.InnerHandler = new HttpClientHandler
+            if (proxy != null)
             {
-                UseProxy = proxy != null,
-                Proxy = proxy
-            };
+                connectionHandler.InnerHandler = new HttpClientHandler
+                {
+                    UseProxy = true,
+                    Proxy = proxy
+                };
+            }
+            else
+            {
+                connectionHandler.InnerHandler = new HttpClientHandler();
+            }
 
             ArangoDatabase.ClientSetting.IsHttpClientInitialied = true;
 
             var httpClient = new HttpClient(connectionHandler, true);
             httpClient.DefaultRequestHeaders.ExpectContinue = false;
-            
+
             httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(".NETClient", Utility.Utils.GetAssemblyVersion()));
 
             return httpClient;
@@ -77,12 +81,12 @@ namespace ArangoDB.Client.Http
                 db.Log("sending http request:");
                 db.Log($"url: {uri.ToString()}");
                 db.Log($"method: {method.ToString()}");
-                if(db.Setting.Logger.HttpHeaders)
+                if (db.Setting.Logger.HttpHeaders)
                 {
                     db.Log($"headers:");
                     foreach (var h in requestMessage.Headers)
-                        db.Log($"{h.Key} : {string.Join(" ",h.Value)}");
-                    foreach(var h in httpClient.DefaultRequestHeaders)
+                        db.Log($"{h.Key} : {string.Join(" ", h.Value)}");
+                    foreach (var h in httpClient.DefaultRequestHeaders)
                         db.Log($"{h.Key} : {string.Join(" ", h.Value)}");
                 }
                 if (db.Setting.Logger.LogOnlyLightOperations == false)

--- a/src/ArangoDB.Client/Utility/Utils.cs
+++ b/src/ArangoDB.Client/Utility/Utils.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ArangoDB.Client.Utility
 {
@@ -65,7 +61,7 @@ namespace ArangoDB.Client.Utility
 
         public static string TraversalStrategyToString(TraversalStrategy strategy)
         {
-            switch(strategy)
+            switch (strategy)
             {
                 case TraversalStrategy.BreadthFirst:
                     return "breadthfirst";
@@ -104,19 +100,35 @@ namespace ArangoDB.Client.Utility
             }
         }
 
+        private static bool IsRunningOnMono
+        {
+            get
+            {
+                return Type.GetType("Mono.Runtime") != null;
+            }
+        }
+
+        private static string AssemblyVersion;
+
         public static string GetAssemblyVersion()
         {
+            if(!string.IsNullOrEmpty(AssemblyVersion))
+            {
+                return AssemblyVersion;
+            }
+
 #if !PORTABLE
             //var version = System.Reflection.Assembly.GetEntryAssembly().GetName().Version;
-            //return version.Major + "." + version.Minor;
-            return "";
+            var version = Assembly.GetAssembly(typeof(ArangoDatabase)).GetName().Version;
+            AssemblyVersion = version.Major + "." + version.Minor;
 #else
             // from http://stackoverflow.com/a/16525426/1271333
             var assembly = typeof(ArangoDatabase).GetTypeInfo().Assembly;
             // In some PCL profiles the above line is: var assembly = typeof(MyType).Assembly;
             var assemblyName = new AssemblyName(assembly.FullName);
-            return assemblyName.Version.Major + "." + assemblyName.Version.Minor;
+            AssemblyVersion = assemblyName.Version.Major + "." + assemblyName.Version.Minor;
 #endif
+            return AssemblyVersion;
         }
     }
 }


### PR DESCRIPTION
Change the way the proxy is assigned to work with mono, and uncommented the way to get the assembly version to be added to the Request Headers