### PR TITLE
Added a way to change the objects are serialized CustomJsonSerializerSettings

### DIFF
--- a/src/ArangoDB.Client/DatabaseSetting.cs
+++ b/src/ArangoDB.Client/DatabaseSetting.cs
@@ -15,11 +15,11 @@ namespace ArangoDB.Client
 
         private bool? _disableChangeTracking;
 
-        DatabaseSharedSetting sharedSetting;
+        public DatabaseSharedSetting SharedSetting { get; set; }
 
         public DatabaseSetting(DatabaseSharedSetting sharedSetting)
         {
-            this.sharedSetting = sharedSetting;
+            this.SharedSetting = sharedSetting;
             this.Cursor = new DatabaseCursorSetting(sharedSetting);
             this.Document = new DatabaseDocumentSetting(sharedSetting);
             this.Linq = new DatabaseLinqSetting(sharedSetting);
@@ -34,7 +34,7 @@ namespace ArangoDB.Client
                 if (_waitForSync.HasValue)
                     return _waitForSync.Value;
 
-                return sharedSetting.WaitForSync;
+                return SharedSetting.WaitForSync;
             }
             set { _waitForSync = value; }
         }
@@ -46,7 +46,7 @@ namespace ArangoDB.Client
                 if (_throwForServerErrors.HasValue)
                     return _throwForServerErrors.Value;
 
-                return sharedSetting.ThrowForServerErrors;
+                return SharedSetting.ThrowForServerErrors;
             }
             set { _throwForServerErrors = value; }
         }
@@ -58,7 +58,7 @@ namespace ArangoDB.Client
                 if (_disableChangeTracking.HasValue)
                     return _disableChangeTracking.Value;
 
-                return sharedSetting.DisableChangeTracking;
+                return SharedSetting.DisableChangeTracking;
             }
             set { _disableChangeTracking = value; }
         }
@@ -83,7 +83,7 @@ namespace ArangoDB.Client
         private bool? _httpResponse;
         private bool? _httpHeaders;
 
-        DatabaseSharedSetting sharedSetting;
+        private DatabaseSharedSetting sharedSetting;
 
         public DatabaseLogSetting(DatabaseSharedSetting sharedSetting)
         {
@@ -101,8 +101,6 @@ namespace ArangoDB.Client
             }
             set { _log = value; }
         }
-
-
 
         public bool LogOnlyLightOperations
         {
@@ -167,7 +165,7 @@ namespace ArangoDB.Client
 
     public class DatabaseSerializationSetting
     {
-        DatabaseSharedSetting sharedSetting;
+        private DatabaseSharedSetting sharedSetting;
 
         private IList<JsonConverter> _converters;
 
@@ -221,7 +219,7 @@ namespace ArangoDB.Client
 
     public class DatabaseLinqSetting
     {
-        DatabaseSharedSetting sharedSetting;
+        private DatabaseSharedSetting sharedSetting;
 
         private Func<string, string> _translateGroupByIntoName;
 
@@ -245,7 +243,7 @@ namespace ArangoDB.Client
 
     public class DatabaseCursorSetting
     {
-        DatabaseSharedSetting sharedSetting;
+        private DatabaseSharedSetting sharedSetting;
 
         private int? _batchSize;
 
@@ -326,7 +324,7 @@ namespace ArangoDB.Client
 
     public class DatabaseDocumentSetting
     {
-        DatabaseSharedSetting sharedSetting;
+        private DatabaseSharedSetting sharedSetting;
 
         private ReplacePolicy? _replacePolicy;
 

--- a/src/ArangoDB.Client/DatabaseSetting.cs
+++ b/src/ArangoDB.Client/DatabaseSetting.cs
@@ -1,9 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ArangoDB.Client
 {
@@ -15,7 +12,7 @@ namespace ArangoDB.Client
 
         private bool? _disableChangeTracking;
 
-        public DatabaseSharedSetting SharedSetting { get; set; }
+        public DatabaseSharedSetting SharedSetting { get; private set; }
 
         public DatabaseSetting(DatabaseSharedSetting sharedSetting)
         {

--- a/src/ArangoDB.Client/DatabaseSharedSetting.cs
+++ b/src/ArangoDB.Client/DatabaseSharedSetting.cs
@@ -1,17 +1,10 @@
-﻿using Newtonsoft.Json;
-using ArangoDB.Client.Http;
-using ArangoDB.Client.Query;
+﻿using ArangoDB.Client.Http;
 using ArangoDB.Client.Property;
-using ArangoDB.Client.Utility;
+using ArangoDB.Client.Query;
+using Newtonsoft.Json;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Net;
-using System.Net.Http;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ArangoDB.Client
 {
@@ -39,7 +32,7 @@ namespace ArangoDB.Client
                 HttpHeaders = false
             };
         }
-        
+
         private string _url;
 
         public string Url
@@ -61,14 +54,14 @@ namespace ArangoDB.Client
         public bool WaitForSync { get; set; }
 
         public bool ThrowForServerErrors { get; set; }
-        
+
         public NetworkCredential SystemDatabaseCredential { get; set; }
 
         public bool ClusterMode { get; set; }
 
         public bool DisableChangeTracking { get; set; }
 
-        public DatabaseLogSharedSetting Logger{ get; set; }
+        public DatabaseLogSharedSetting Logger { get; set; }
 
         public DatabaseCursorSharedSetting Cursor { get; set; }
 
@@ -83,6 +76,8 @@ namespace ArangoDB.Client
         internal DocumentIdentifierModifier IdentifierModifier;
 
         internal AqlFunctionCache AqlFunctions { get; set; }
+
+        public Func<IArangoDatabase, List<JsonConverter>, JsonSerializer> CustomJsonSerializer;
     }
 
     public class DatabaseSerializationSharedSetting
@@ -118,7 +113,7 @@ namespace ArangoDB.Client
 
     public class DatabaseLinqSharedSetting
     {
-        public Func<string,string> TranslateGroupByIntoName { get; set; }
+        public Func<string, string> TranslateGroupByIntoName { get; set; }
     }
 
     public class DatabaseDocumentSharedSetting

--- a/src/ArangoDB.Client/Serialization/DocumentSerializer.cs
+++ b/src/ArangoDB.Client/Serialization/DocumentSerializer.cs
@@ -3,20 +3,15 @@ using ArangoDB.Client.Serialization.Converters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ArangoDB.Client.Serialization
 {
     public class DocumentSerializer
     {
         private IArangoDatabase db;
-
-        public static Func<IArangoDatabase, JsonSerializer> CustomJsonSerializer;
 
         public DocumentSerializer(IArangoDatabase db)
         {
@@ -79,33 +74,31 @@ namespace ArangoDB.Client.Serialization
 
         public JsonSerializer CreateJsonSerializer()
         {
-            if (CustomJsonSerializer == null)
+            if (db.Setting.SharedSetting.CustomJsonSerializer == null)
             {
                 var jsonSerializer = JsonSerializer.Create(SerializerSetting);
 
                 return jsonSerializer;
             }
-
-            return CustomJsonSerializer(db);
+            return db.Setting.SharedSetting.CustomJsonSerializer(db, GetJsonConverters());
         }
 
         public JsonSerializerSettings SerializerSetting
         {
             get
             {
-                List<JsonConverter> convertes = GetConverters();
+                List<JsonConverter> convertes = GetJsonConverters();
 
                 return new JsonSerializerSettings
                 {
                     ContractResolver = DocumentContractResolver.GetContractResolver(db),
                     Converters = convertes,
-                    DateParseHandling = DateParseHandling.None,
-                    MetadataPropertyHandling = db.Setting.Serialization.MetadataPropertyHandling
+                    DateParseHandling = DateParseHandling.None
                 };
             }
         }
 
-        private List<JsonConverter> GetConverters()
+        private List<JsonConverter> GetJsonConverters()
         {
             var convertes = new List<JsonConverter>
                 {

--- a/src/ArangoDB.Client/Serialization/DocumentSerializer.cs
+++ b/src/ArangoDB.Client/Serialization/DocumentSerializer.cs
@@ -93,15 +93,7 @@ namespace ArangoDB.Client.Serialization
         {
             get
             {
-                var convertes = new List<JsonConverter>
-                {
-                    new DateTimeConverter(),
-                    new QueryParameterConverter(),
-                    new EnumValueConverter()
-                }.Concat(db.Setting.Serialization.Converters).ToList();
-
-                if (db.Setting.Serialization.SerializeEnumAsInteger == false)
-                    convertes.Add(new StringEnumConverter());
+                List<JsonConverter> convertes = GetConverters();
 
                 return new JsonSerializerSettings
                 {
@@ -111,6 +103,20 @@ namespace ArangoDB.Client.Serialization
                     MetadataPropertyHandling = db.Setting.Serialization.MetadataPropertyHandling
                 };
             }
+        }
+
+        private List<JsonConverter> GetConverters()
+        {
+            var convertes = new List<JsonConverter>
+                {
+                    new DateTimeConverter(),
+                    new QueryParameterConverter(),
+                    new EnumValueConverter()
+                }.Concat(db.Setting.Serialization.Converters).ToList();
+
+            if (db.Setting.Serialization.SerializeEnumAsInteger == false)
+                convertes.Add(new StringEnumConverter());
+            return convertes;
         }
 
         public JObject FromObject(object document)


### PR DESCRIPTION
I had a problem with the way the the Date was serialized and saved in the database. I needed to be saved with the format ISO 8601....

So I added a function in `DatabaseSharedSetting` to change the JsonSerializerSettings

```
var setting = new DatabaseSharedSetting();
...
setting.CustomJsonSerializer = (db, converters) =>
{
    return JsonSerializer.Create(
        new JsonSerializerSettings
        {
            ContractResolver =  ArangoDB.Client.Serialization.DocumentContractResolver.GetContractResolver(db),
            Converters = converters,
            DateParseHandling = DateParseHandling.None,
            DateTimeZoneHandling = DateTimeZoneHandling.Utc
        });
};
```