### PR TITLE
Forced UseProxy to false when no proxy

### DIFF
--- a/src/ArangoDB.Client/Http/HttpConnection.cs
+++ b/src/ArangoDB.Client/Http/HttpConnection.cs
@@ -28,7 +28,11 @@ namespace ArangoDB.Client.Http
             }
             else
             {
-                connectionHandler.InnerHandler = new HttpClientHandler();
+                connectionHandler.InnerHandler = new HttpClientHandler()
+                {
+                    UseProxy = false,
+                    Proxy = null
+                };
             }
 
             var httpClient = new HttpClient(connectionHandler, true);


### PR DESCRIPTION
Found this StackOverflow question: http://stackoverflow.com/questions/35084773/why-is-first-httpclient-postasync-call-extremely-slow-in-my-c-sharp-winforms-app , and it answered my issues on slow queries through HTTP (#66 - https://github.com/ra0o0f/arangoclient.net/issues/66)

After stepping into the code through debugging, I noticed the HttpClient handler had UseProxy as true even though no proxy. This might be the default setting. So explicitly setting the field to false made all the difference. The HTTP query runs in 10ms now.