### PR TITLE
Allow JsonProperty(PropertyName='blah') to be used during Serialization

### DIFF
--- a/src/ArangoDB.Client.Test/ArangoDB.Client.Test.Net45.csproj
+++ b/src/ArangoDB.Client.Test/ArangoDB.Client.Test.Net45.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Model\Product.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Serialization\NamingConvention.cs" />
+    <Compile Include="Serialization\PropertyNames.cs" />
     <Compile Include="Serialization\SimpleDocumentParser.cs" />
     <Compile Include="Setting\SerializationSetting.cs" />
     <Compile Include="Utility\ObjectUtility.cs" />

--- a/src/ArangoDB.Client.Test/ArangoDB.Client.Test.Portable.csproj
+++ b/src/ArangoDB.Client.Test/ArangoDB.Client.Test.Portable.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Model\Product.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Serialization\NamingConvention.cs" />
+    <Compile Include="Serialization\PropertyNames.cs" />
     <Compile Include="Serialization\SimpleDocumentParser.cs" />
     <Compile Include="Setting\SerializationSetting.cs" />
     <Compile Include="Utility\ObjectUtility.cs" />

--- a/src/ArangoDB.Client.Test/Serialization/PropertyNames.cs
+++ b/src/ArangoDB.Client.Test/Serialization/PropertyNames.cs
@@ -1,0 +1,71 @@
+﻿using System.IO;
+using Xunit;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using ArangoDB.Client.Serialization;
+
+namespace ArangoDB.Client.Test.Serialization {
+	public class PropertyNames {
+
+		private IArangoDatabase _db;
+		private ObjectToSerialize _toTest;
+		private DocumentSerializer _docSerializer;
+		private JsonSerializer _jsonSerializer;
+
+		public PropertyNames(){
+			_toTest = new ObjectToSerialize();
+			_db = new ArangoDatabase();
+			_docSerializer = new DocumentSerializer(_db);
+			_jsonSerializer = _docSerializer.CreateJsonSerializer();
+		}
+		
+		[Fact]
+		public void UseUnderlyingNames()
+		{
+
+			_db.SharedSetting.Serialization.UseUnderlyingPropertyName = true;
+
+			string testData = SerializeTestObject();
+			JObject jo = JObject.Parse(testData);
+
+			Assert.NotNull(jo["TestProp02"]);
+		}
+
+		[Fact]
+		public void UseJsonPropertyNames()
+		{
+			_db.SharedSetting.Serialization.UseUnderlyingPropertyName = false;
+
+			string testData = SerializeTestObject();
+			JObject jo = JObject.Parse(testData);
+
+			Assert.NotNull(jo["MyTestProp"]);
+		}
+
+		private string SerializeTestObject(){
+			string retVal = null;
+
+			using (MemoryStream ms = new MemoryStream(1024)) {
+				using (StreamWriter sw = new StreamWriter(ms)) {
+					using (JsonWriter jw = new JsonTextWriter(sw)) {
+						_jsonSerializer.Serialize(jw, _toTest);
+						sw.Flush();
+						ms.Seek(0, SeekOrigin.Begin);
+
+						using (StreamReader sr = new StreamReader(ms)) {
+							retVal = sr.ReadToEnd();
+						}
+					}
+				}
+			}
+			return retVal;
+		}
+
+		private class ObjectToSerialize {
+			public bool TestProp01 { get; set; }
+
+			[JsonProperty(PropertyName = "MyTestProp")]
+			public bool TestProp02 { get; set; }
+		}
+	}
+}

--- a/src/ArangoDB.Client/DatabaseSharedSetting.cs
+++ b/src/ArangoDB.Client/DatabaseSharedSetting.cs
@@ -96,9 +96,12 @@ namespace ArangoDB.Client
             SerializeEnumAsInteger = true;
             MetadataPropertyHandling = Newtonsoft.Json.MetadataPropertyHandling.Default;
             Converters = new List<JsonConverter>();
+			UseUnderlyingPropertyName = false;
         }
 
         public MetadataPropertyHandling MetadataPropertyHandling { get; set; }
+
+		public bool UseUnderlyingPropertyName { get; set; }
     }
 
     public class DatabaseLogSharedSetting

--- a/src/ArangoDB.Client/Serialization/DocumentContractResolver.cs
+++ b/src/ArangoDB.Client/Serialization/DocumentContractResolver.cs
@@ -48,8 +48,9 @@ namespace ArangoDB.Client.Serialization
                         continue;
 
 					// this change allows the JsonProperty.PropertyName to be used instead of the Object.PropertyName
-					if (p.PropertyName != p.UnderlyingName)
+					if (!sharedSetting.Serialization.UseUnderlyingPropertyName && p.PropertyName != p.UnderlyingName) {
 						documentProperty.PropertyName = p.PropertyName;
+					}
                 }
 
                 p.PropertyName = sharedSetting.Collection.ResolvePropertyName(type, p.UnderlyingName);

--- a/src/ArangoDB.Client/Serialization/DocumentContractResolver.cs
+++ b/src/ArangoDB.Client/Serialization/DocumentContractResolver.cs
@@ -46,6 +46,10 @@ namespace ArangoDB.Client.Serialization
                 {
                     if (documentProperty.IgnoreProperty)
                         continue;
+
+					// this change allows the JsonProperty.PropertyName to be used instead of the Object.PropertyName
+					if (p.PropertyName != p.UnderlyingName)
+						documentProperty.PropertyName = p.PropertyName;
                 }
 
                 p.PropertyName = sharedSetting.Collection.ResolvePropertyName(type, p.UnderlyingName);


### PR DESCRIPTION
This addresses the issue with using the JsonProperty(PropertyName="") where the decorated property name is not propogated to the server during the insert/update to the ArangoDB instance.