### PR TITLE
added a way to submit additional query parameters while executing a LINQ query as a cursor

### DIFF
--- a/src/ArangoDB.Client/Extentions/QueryableExtensions.cs
+++ b/src/ArangoDB.Client/Extentions/QueryableExtensions.cs
@@ -126,6 +126,11 @@ namespace ArangoDB.Client
             return source.AsArangoQueryable<T>().AsCursor();
         }
 
+        public static ICursor<T> AsCursor<T>(this IQueryable<T> source, bool? count = null, int? batchSize = null, TimeSpan? ttl = null, QueryOption options = null)
+        {
+            return source.AsArangoQueryable<T>().AsCursor(count, batchSize, ttl, options);
+        }
+
         public static void Execute<T>(this IAqlModifiable<T> source)
         {
             // AsCursor is needed for executing query by ArangoQueryable methods instead of ArangoQueryExecuter

--- a/src/ArangoDB.Client/Property/DatabaseCollectionSetting.cs
+++ b/src/ArangoDB.Client/Property/DatabaseCollectionSetting.cs
@@ -253,9 +253,7 @@ namespace ArangoDB.Client.Property
 
         public string ResolvePropertyName<T>(Expression<Func<T, object>> attribute)
         {
-            var memberInfo = Utils.GetMemberInfo<T>(attribute);
-
-            return ResolvePropertyName(typeof(T), memberInfo.Name);
+            return ResolvePropertyName(typeof(T), Utils.GetPropertyName(attribute));
         }
 
         internal string ResolveNestedPropertyName<T>(Expression<Func<T, object>> attribute)

--- a/src/ArangoDB.Client/Property/DocumentPropertySetting.cs
+++ b/src/ArangoDB.Client/Property/DocumentPropertySetting.cs
@@ -37,7 +37,11 @@ namespace ArangoDB.Client.Property
                 cachedAttributeProperties.TryAdd(type, typeSetting);
             }
 
-            return typeSetting[memberName];
+            //check if the property existing in the dictionary and return it in case it does
+            if (typeSetting.TryGetValue(memberName, out IDocumentPropertySetting documentPropertySetting))
+                return documentPropertySetting;
+
+            return null;
         }
 
         internal static IDocumentPropertySetting FindDocumentAttributeForType<T>(Expression<Func<T, object>> attribute)

--- a/src/ArangoDB.Client/Query/ArangoQueryable.cs
+++ b/src/ArangoDB.Client/Query/ArangoQueryable.cs
@@ -82,5 +82,11 @@ namespace ArangoDB.Client.Query
             return db.CreateStatement<T>(queryData.Query
                 , bindVars: queryData.BindVars);
         }
+
+        public ICursor<T> AsCursor(bool? count = null, int? batchSize = null, TimeSpan? ttl = null, QueryOption options = null)
+        {
+            var queryData = GetQueryData();
+            return db.CreateStatement<T>(queryData.Query, queryData.BindVars, count, batchSize, ttl, options);
+        }
     }
 }

--- a/src/ArangoDB.Client/Utility/Utils.cs
+++ b/src/ArangoDB.Client/Utility/Utils.cs
@@ -20,6 +20,28 @@ namespace ArangoDB.Client.Utility
             }
         }
 
+        public static string GetPropertyName<TModel, TValue>(Expression<Func<TModel, TValue>> attribute)
+        {
+            const char delimiterDot = '.';
+            const char delimiterPlus = '+';
+            const char delimiterComma = ',';
+            const char endTrim = ')';
+            
+            var asString = attribute.ToString(); // gives you: "o => o.Whatever"
+            //now we need to replace the plus signs with the dots in case of the nesting classes
+            asString = asString.Replace(delimiterPlus, delimiterDot);
+            // make sure there is a beginning property indicator; the "." in "o.Whatever"
+            var firstDotDelim = asString.IndexOf(delimiterDot);
+            var firstCommaDelim = asString.IndexOf(delimiterComma);
+
+            if (firstDotDelim < 0)
+                return asString;
+            else if (firstCommaDelim < 0)
+                return asString.Substring(firstDotDelim + 1).TrimEnd(endTrim);
+            else
+                return asString.Substring(firstDotDelim + 1, firstCommaDelim - firstDotDelim - 1);
+        }
+
         public static MemberInfo GetMemberInfo<T>(Expression<Func<T, object>> attribute)
         {
             return GetMemberExpression(attribute).Member;


### PR DESCRIPTION
Currently the query options can only submitted while executing a query as CreateStatement, like this:

`db.CreateStatement<Person>("for p in Person limit 1,1 return p", null, true, null, null, new QueryOption {FullCount = true});`

the change allows to execute a query as a LINQ statement:
`db.Query<Person>().Select(p => p.Age).Skip(1).Take(1).AsCursor(true, null, null, new QueryOption { FullCount = true });`