### PR TITLE
make sure that the property name are properly resolved regardless if it's a nested property or not

### DIFF
--- a/src/ArangoDB.Client/Property/DatabaseCollectionSetting.cs
+++ b/src/ArangoDB.Client/Property/DatabaseCollectionSetting.cs
@@ -253,9 +253,7 @@ namespace ArangoDB.Client.Property
 
         public string ResolvePropertyName<T>(Expression<Func<T, object>> attribute)
         {
-            var memberInfo = Utils.GetMemberInfo<T>(attribute);
-
-            return ResolvePropertyName(typeof(T), memberInfo.Name);
+            return ResolvePropertyName(typeof(T), Utils.GetPropertyName(attribute));
         }
 
         internal string ResolveNestedPropertyName<T>(Expression<Func<T, object>> attribute)

--- a/src/ArangoDB.Client/Property/DocumentPropertySetting.cs
+++ b/src/ArangoDB.Client/Property/DocumentPropertySetting.cs
@@ -37,7 +37,11 @@ namespace ArangoDB.Client.Property
                 cachedAttributeProperties.TryAdd(type, typeSetting);
             }
 
-            return typeSetting[memberName];
+            //check if the property existing in the dictionary and return it in case it does
+            if (typeSetting.TryGetValue(memberName, out IDocumentPropertySetting documentPropertySetting))
+                return documentPropertySetting;
+
+            return null;
         }
 
         internal static IDocumentPropertySetting FindDocumentAttributeForType<T>(Expression<Func<T, object>> attribute)

--- a/src/ArangoDB.Client/Utility/Utils.cs
+++ b/src/ArangoDB.Client/Utility/Utils.cs
@@ -20,6 +20,28 @@ namespace ArangoDB.Client.Utility
             }
         }
 
+        public static string GetPropertyName<TModel, TValue>(Expression<Func<TModel, TValue>> attribute)
+        {
+            const char delimiterDot = '.';
+            const char delimiterPlus = '+';
+            const char delimiterComma = ',';
+            const char endTrim = ')';
+            
+            var asString = attribute.ToString(); // gives you: "o => o.Whatever"
+            //now we need to replace the plus signs with the dots in case of the nesting classes
+            asString = asString.Replace(delimiterPlus, delimiterDot);
+            // make sure there is a beginning property indicator; the "." in "o.Whatever"
+            var firstDotDelim = asString.IndexOf(delimiterDot);
+            var firstCommaDelim = asString.IndexOf(delimiterComma);
+
+            if (firstDotDelim < 0)
+                return asString;
+            else if (firstCommaDelim < 0)
+                return asString.Substring(firstDotDelim + 1).TrimEnd(endTrim);
+            else
+                return asString.Substring(firstDotDelim + 1, firstCommaDelim - firstDotDelim - 1);
+        }
+
         public static MemberInfo GetMemberInfo<T>(Expression<Func<T, object>> attribute)
         {
             return GetMemberExpression(attribute).Member;


### PR DESCRIPTION
the property name resolution works in the following scenarios as well, regardless if these classes are nested or not:

```
class Person
        {
            [DocumentProperty(Identifier = IdentifierType.Key)]
            public string Key { get; set; }
            public string Name { get; set; }
            public int Age { get; set; }

            public Address Address { get; set; }
        }

        class Address
        {
            public string Street { get; set; }
            public string City { get; set; }
        }
```

previously defining an index on Address.Street would create and index on Street which is wrong

```
db.Advanced.EnsureIndex<Person>(new EnsureIndexData
                    {
                        Type = IndexType.Hash,
                        Unique = false,
                        Fields = new List<string> {
                            //"cell",
                            // or if you dont want use strings
                            db.SharedSetting.Collection.ResolvePropertyName<Person>(x=>x.Address.Street)
                        }
                    });
```
