### PR TITLE
Added ServerResult property on ArangoServerException

### DIFF
--- a/src/ArangoDB.Client/ArangoServerException.cs
+++ b/src/ArangoDB.Client/ArangoServerException.cs
@@ -9,9 +9,15 @@ namespace ArangoDB.Client
 {
     public class ArangoServerException : Exception
     {
+        /// <summary>
+        /// The result object that was received from the server.
+        /// </summary>
+        public BaseResult ServerResult { get; }
+
         public ArangoServerException(BaseResult baseResult)
             : base(string.Format("{0}. ErrorNumber: {1} HttpStatusCode: {2}", baseResult.ErrorMessage, baseResult.ErrorNum, baseResult.Code))
         {
+            this.ServerResult = baseResult;
         }
 
         public ArangoServerException(string message)


### PR DESCRIPTION
For convenience, we need to get the ErrorNum when catching an `ArangoServerException`.

This pull request gives access to the `BaseResult` that was used to build the exception instance.